### PR TITLE
remove nonexistent `output_files` block

### DIFF
--- a/mf6/test054_xt3d_whirlsA/model.nam
+++ b/mf6/test054_xt3d_whirlsA/model.nam
@@ -6,10 +6,3 @@ BEGIN PACKAGES
   WEL6             model.wel
   OC6              model.oc
 END PACKAGES
-
-BEGIN OUTPUT_FILES
-  LIST             model.list
-  DATA(BINARY)     model.hds REPLACE
-  DATA(BINARY)     model.ddn REPLACE
-  DATA(BINARY)     model.cbc REPLACE
-END OUTPUT_FILES

--- a/mf6/test054_xt3d_whirlsB/model.nam
+++ b/mf6/test054_xt3d_whirlsB/model.nam
@@ -6,10 +6,3 @@ BEGIN PACKAGES
   WEL6             model.wel
   OC6              model.oc
 END PACKAGES
-
-BEGIN OUTPUT_FILES
-  LIST             model.list
-  DATA(BINARY)     model.hds REPLACE
-  DATA(BINARY)     model.ddn REPLACE
-  DATA(BINARY)     model.cbc REPLACE
-END OUTPUT_FILES

--- a/mf6/test054_xt3d_whirlsC/model.nam
+++ b/mf6/test054_xt3d_whirlsC/model.nam
@@ -6,10 +6,3 @@ BEGIN PACKAGES
   WEL6             model.wel
   OC6              model.oc
 END PACKAGES
-
-BEGIN OUTPUT_FILES
-  LIST             model.list
-  DATA(BINARY)     model.hds REPLACE
-  DATA(BINARY)     model.ddn REPLACE
-  DATA(BINARY)     model.cbc REPLACE
-END OUTPUT_FILES


### PR DESCRIPTION
Perhaps left from an older design.
Not sure what the desired behavior is on adding blocks like this, perhaps MODFLOW should throw an error?