### PR TITLE
Use print() function in both Python 2 and Python 3 

### DIFF
--- a/mf6/foldersize.py
+++ b/mf6/foldersize.py
@@ -28,4 +28,7 @@ result.reverse()
 for i in result:
   print ('{0:50} ==> '.format(i[1])+'%0.1f MB' %i[0])
 
-raw_input()
+try:
+  raw_input()  # Python 2
+except NameError:
+  input()      # Python 3

--- a/mf6/test033_wtdecay/mfnwt/createghb.py
+++ b/mf6/test033_wtdecay/mfnwt/createghb.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import numpy as np
 
@@ -19,7 +20,7 @@ h2 = 3.05
 
 xmax = dx * float(ncol)
 ymax = dx * float(nrow)
-print xmax, ymax
+print(xmax, ymax)
 
 #--x
 x = np.arange(0, xmax, dx) + dx/2.
@@ -33,7 +34,7 @@ X, Y = np.meshgrid(x, y[::-1])
 xc, yc = X[75, 75], Y[75, 75]
 
 R = np.sqrt((X-xc)**2 + (Y-yc)**2)
-print R.min(), R.max()
+print(R.min(), R.max())
 
 h = analwt(h1, h2, xmax/2., R)
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.